### PR TITLE
docs: add build and install from source instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,58 @@ A rich terminal UI for GitHub that doesn't break your flow.
 - Everything you can do on GitHub - diff, comment, checkout, push, update etc.
 - Control every setting with a YAML config file
 
+## 🔧 Building & Installing from Source
+
+No releases are published from this fork — you must build and install from source.
+
+### Prerequisites
+
+- **[GitHub CLI (`gh`)](https://cli.github.com/)** — required at runtime for auth and as the extension host (`gh auth login` before first run)
+- **[Go 1.23+](https://go.dev/dl/)** — compiler
+- **[go-task](https://taskfile.dev/installation/)** — task runner (`task` CLI)
+
+### Option A: Devbox (recommended)
+
+[Devbox](https://www.jetpack.io/devbox) pins the exact toolchain (Go, go-task, linters) used in CI. One command sets everything up:
+
+```sh
+curl -fsSL https://get.jetpack.io/devbox | bash
+git clone https://github.com/AngelCantugr/gh-dash && cd gh-dash
+devbox shell          # installs Go 1.23, go-task, gh, linters automatically
+task install          # build → install as gh extension → verify
+```
+
+### Option B: Manual (Go + go-task already installed)
+
+```sh
+git clone https://github.com/AngelCantugr/gh-dash && cd gh-dash
+gh auth login         # if not already authenticated
+task install          # build → install as gh extension → verify
+```
+
+Or without go-task:
+
+```sh
+go build .
+gh ext install .
+gh dash --version
+```
+
+### Updating
+
+```sh
+git pull
+task install          # rebuild and reinstall
+```
+
+### Uninstalling
+
+```sh
+gh ext remove dash
+```
+
+---
+
 ## ❤️ Donating
 
 If you enjoy `DASH` and want to help, consider supporting the project with a

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ No releases are published from this fork — you must build and install from sou
 
 ```sh
 curl -fsSL https://get.jetpack.io/devbox | bash
-git clone https://github.com/AngelCantugr/gh-dash && cd gh-dash
+git clone https://github.com/AngelCantugr/gh-dash dash && cd dash
 devbox shell          # installs Go 1.23, go-task, gh, linters automatically
 task install          # build → install as gh extension → verify
 ```
@@ -37,7 +37,7 @@ task install          # build → install as gh extension → verify
 ### Option B: Manual (Go + go-task already installed)
 
 ```sh
-git clone https://github.com/AngelCantugr/gh-dash && cd gh-dash
+git clone https://github.com/AngelCantugr/gh-dash dash && cd dash
 gh auth login         # if not already authenticated
 task install          # build → install as gh extension → verify
 ```
@@ -54,7 +54,7 @@ gh dash --version
 
 ```sh
 git pull
-task install          # rebuild and reinstall
+task install          # rebuild and reinstall — or: go build . && gh ext install .
 ```
 
 ### Uninstalling


### PR DESCRIPTION
## Summary

- Adds a `🔧 Building & Installing from Source` section to `README.md`, placed immediately after Features so it's the first thing a new visitor sees
- Covers two setup paths: **Devbox** (recommended — pins the exact toolchain via `devbox.json`) and **Manual** (for users who already have Go and go-task)
- Includes prerequisites with links (gh CLI, Go 1.23+, go-task), step-by-step commands, and Updating/Uninstalling snippets

## Why

This fork does not publish releases — users must build from source. The README previously had no installation section at all, leaving new users with no guidance.

## Reviewer notes

All commands (`task install`, `gh ext install .`, `gh ext remove dash`, `go build .`) are sourced directly from `Taskfile.yaml` and verified against the project's actual toolchain config (`devbox.json`, `go.mod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)